### PR TITLE
rpma: install PMDK libraries in Travis CI

### DIFF
--- a/ci/travis-install-librpma.sh
+++ b/ci/travis-install-librpma.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
-set -e
+#!/bin/bash -e
 
 # librpma v0.9.0 release
 LIBRPMA_VERSION=0.9.0
 
+WORKDIR=$(pwd)
+
+# install librpma
 git clone https://github.com/pmem/rpma.git
 mkdir -p rpma/build
 cd rpma/build
@@ -15,5 +17,5 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 	-DBUILD_TESTS=OFF
 make -j$(nproc)
 sudo make -j$(nproc) install
-cd ../..
+cd $WORKDIR
 rm -rf rpma

--- a/ci/travis-install-pmdk.sh
+++ b/ci/travis-install-pmdk.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# pmdk v1.9.1 release
+PMDK_VERSION=1.9.1
+
+WORKDIR=$(pwd)
+
+#
+# The '/bin/sh' shell used by PMDK's 'make install'
+# does not know the exact localization of clang
+# and fails with:
+#    /bin/sh: 1: clang: not found
+# if CC is not set to the full path of clang.
+#
+export CC=$(which $CC)
+
+# Install PMDK libraries, because PMDK's libpmem
+# is a dependency of the librpma fio engine.
+# Install it from a release package
+# with already generated documentation,
+# in order to not install 'pandoc'.
+wget https://github.com/pmem/pmdk/releases/download/${PMDK_VERSION}/pmdk-${PMDK_VERSION}.tar.gz
+tar -xzf pmdk-${PMDK_VERSION}.tar.gz
+cd pmdk-${PMDK_VERSION}
+make -j$(nproc) NDCTL_ENABLE=n
+sudo make -j$(nproc) install prefix=/usr NDCTL_ENABLE=n
+cd $WORKDIR
+rm -rf pmdk-${PMDK_VERSION}

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -49,6 +49,9 @@ case "$TRAVIS_OS_NAME" in
 	sudo apt-get install --no-install-recommends -qq -y "${pkgs[@]}"
 	# librpma is supported on the amd64 (x86_64) architecture for now
 	if [[ $CI_TARGET_ARCH == "amd64" ]]; then
+		# PMDK libraries have to be installed, because
+		# libpmem is a dependency of the librpma fio engine
+		ci/travis-install-pmdk.sh
 		# install librpma from sources from GitHub
 		ci/travis-install-librpma.sh
 	fi

--- a/engines/librpma.c
+++ b/engines/librpma.c
@@ -17,6 +17,7 @@
 #include "../hash.h"
 #include "../optgroup.h"
 
+#include <libpmem.h>
 #include <librpma.h>
 
 #define rpma_td_verror(td, err, func) \


### PR DESCRIPTION
The server of librpma depends on libpmem from PMDK,
so PMDK libraries have to be installed in Travis CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/31)
<!-- Reviewable:end -->
