### PR TITLE
rpma: fix server_open_file()

### DIFF
--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -615,7 +615,9 @@ static int server_open_file(struct thread_data *td, struct fio_file *f)
 		goto err_conn_delete;
 
 	/* wait for the connection to be established */
-	ret = rpma_conn_next_event(sd->conn, &conn_event);
+	ret = rpma_conn_next_event(conn, &conn_event);
+	if (ret)
+		rpma_td_verror(td, ret, "rpma_conn_next_event");
 	if (!ret && conn_event != RPMA_CONN_ESTABLISHED) {
 		log_err("rpma_conn_next_event returned an unexptected event\n");
 		ret = 1;


### PR DESCRIPTION
Fix the 'conn' argument of rpma_conn_next_event()
and add an error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/60)
<!-- Reviewable:end -->
