### PR TITLE
rpma: fix client_io_write dst offset calculation

### DIFF
--- a/engines/librpma.c
+++ b/engines/librpma.c
@@ -478,7 +478,7 @@ static inline int client_io_write(struct thread_data *td, struct io_u *io_u, int
 {
 	struct client_data *cd = td->io_ops_data;
 	size_t src_offset = (char *)(io_u->xfer_buf) - cd->orig_buffer_aligned;
-	size_t dst_offset = io_u->offset;
+	size_t dst_offset = cd->ws_offset + io_u->offset;
 
 	int ret = rpma_write(cd->conn,
 			cd->server_mr, dst_offset,


### PR DESCRIPTION
**Note**: The issue being fixed might affect bandwidth(threads) scalability.

@grom72 @ldorau @osalyk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/72)
<!-- Reviewable:end -->
