### PR TITLE
rpma: fix workspace size calculation

### DIFF
--- a/engines/librpma.c
+++ b/engines/librpma.c
@@ -1082,7 +1082,7 @@ static int server_open_file(struct thread_data *td, struct fio_file *f)
 
 	/* prepare a workspace description */
 	sd->ws.mr_desc_size = mr_desc_size;
-	sd->ws.size = td_max_bs(td);
+	sd->ws.size = td->o.size;
 
 	/* attach the workspace to private data structure */
 	sd->pdata.ptr = &sd->ws;


### PR DESCRIPTION
May profoundly affect the results at least in two ways:
- in-situ writes vs e.g. sequential may behave differently
- having bigger workspaces allows easier making use off all available
  PMem DIMMs bandwidth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/101)
<!-- Reviewable:end -->
