### PR TITLE
rpma: gpspm: fix two warnings

### DIFF
--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -142,7 +142,7 @@ struct client_data {
 	int io_u_completed_nr;
 };
 
-#define PORT_STR_LEN_MAX 10
+#define PORT_STR_LEN_MAX 12
 
 static int common_td_port(const char *port_base_str,
 		struct thread_data *td, char *port_out)


### PR DESCRIPTION
The first one:
```
engines/librpma_gpspm.c: In function ‘common_td_port’:
engines/librpma_gpspm.c:167:44: warning: ‘%u’ directive output may be truncated writing between 1 and 10 bytes into a region of size 9 [-Wformat-truncation=]
  167 |  snprintf(port_out, PORT_STR_LEN_MAX - 1, "%u", port_new);
      |                                            ^~
```

The second one:
```
engines/librpma_gpspm.c: In function ‘common_td_port’:
engines/librpma_gpspm.c:167:46: warning: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
  167 |  snprintf(port_out, PORT_STR_LEN_MAX - 1, "%u", port_new);
      |                                              ^
In file included from /usr/include/stdio.h:866,
                 from engines/../fio.h:11,
                 from engines/librpma_gpspm.c:17:
/usr/include/bits/stdio2.h:70:10: note: ‘__builtin___snprintf_chk’ output between 2 and 11 bytes into a destination of size 10
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/106)
<!-- Reviewable:end -->
