### PR TITLE
filesetup: add option to prepopulate file with data

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -1208,6 +1208,15 @@ I/O type
 	write to the end of an extended file will stall until the entire
 	file has been filled with zeroes.
 
+.. option:: prepopulate=bool
+
+	After laying down files it might be expected to fill them with some data.
+	It makes sense only for read jobs (not preceded by a write job).
+	It works on regular files and fills them up block by block. It may take
+	some time to complete (especially with big file and small block size).
+	It makes no sense with fill_device, so don't use these two together.
+	Default: false.
+
 .. option:: fadvise_hint=str
 
 	Use :manpage:`posix_fadvise(2)` or :manpage:`posix_fadvise(2)` to

--- a/cconv.c
+++ b/cconv.c
@@ -254,6 +254,7 @@ void convert_thread_options_to_cpu(struct thread_options *o,
 	o->stats = le32_to_cpu(top->stats);
 	o->fadvise_hint = le32_to_cpu(top->fadvise_hint);
 	o->fallocate_mode = le32_to_cpu(top->fallocate_mode);
+	o->prepopulate = le32_to_cpu(top->prepopulate);
 	o->zero_buffers = le32_to_cpu(top->zero_buffers);
 	o->refill_buffers = le32_to_cpu(top->refill_buffers);
 	o->scramble_buffers = le32_to_cpu(top->scramble_buffers);
@@ -454,6 +455,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	top->stats = cpu_to_le32(o->stats);
 	top->fadvise_hint = cpu_to_le32(o->fadvise_hint);
 	top->fallocate_mode = cpu_to_le32(o->fallocate_mode);
+	top->prepopulate = cpu_to_le32(o->prepopulate);
 	top->zero_buffers = cpu_to_le32(o->zero_buffers);
 	top->refill_buffers = cpu_to_le32(o->refill_buffers);
 	top->scramble_buffers = cpu_to_le32(o->scramble_buffers);

--- a/examples/libpmem.fio
+++ b/examples/libpmem.fio
@@ -10,6 +10,7 @@ disable_lat=1
 disable_slat=1
 disable_clat=1
 clat_percentiles=0
+prepopulate=1
 
 iodepth=1
 iodepth_batch=1

--- a/filesetup.c
+++ b/filesetup.c
@@ -339,6 +339,95 @@ error:
 	return ret;
 }
 
+/*
+ * Prepopulate regular file with data.
+ * Leaves f->fd open on success, caller must close.
+ */
+static int prepopulate_file(struct thread_data *td, struct fio_file *f)
+{
+	int flags;
+	unsigned long long left, bs;
+	char *b = NULL;
+
+	if (read_only) {
+		log_err("fio: refusing extend of file due to read-only\n");
+		return 0;
+	}
+	if (td->o.fill_device) {
+		log_err("fio: prepopulate option with fill_device makes no sense\n");
+		return 0;
+	}
+
+	flags = O_WRONLY;
+	if (td->o.allow_create)
+		flags |= O_CREAT;
+
+#ifdef WIN32
+	flags |= _O_BINARY;
+#endif
+
+	dprint(FD_FILE, "open file %s, flags %x\n", f->file_name, flags);
+	f->fd = open(f->file_name, flags, 0644);
+	if (f->fd < 0) {
+		int err = errno;
+
+		if (err == ENOENT && !td->o.allow_create)
+			log_err("fio: file creation disallowed by "
+					"allow_file_create=0\n");
+		else
+			td_verror(td, err, "open");
+		return 1;
+	}
+
+	left = f->real_file_size; // XXX ?? f->file_offset + f->io_size
+	bs = td->o.max_bs[DDIR_WRITE];
+	if (bs > left)
+		bs = left;
+
+	b = malloc(bs);
+	if (!b) {
+		td_verror(td, errno, "malloc");
+		goto err;
+	}
+
+	while (left && !td->terminate) {
+		ssize_t r;
+
+		if (bs > left)
+			bs = left;
+
+		fill_io_buffer(td, b, bs, bs);
+
+		r = write(f->fd, b, bs);
+
+		if (r > 0) {
+			left -= r;
+		} else {
+			td_verror(td, errno, "write");
+			goto err;
+		}
+	}
+
+	if (td->terminate) {
+		dprint(FD_FILE, "terminate unlink %s\n", f->file_name);
+		td_io_unlink_file(td, f);
+	} else if (td->o.create_fsync) {
+		if (fsync(f->fd) < 0) {
+			td_verror(td, errno, "fsync");
+			goto err;
+		}
+	}
+
+	free(b);
+	return 0;
+err:
+	close(f->fd);
+	f->fd = -1;
+	if (b)
+		free(b);
+	return 1;
+}
+
 unsigned long long get_rand_file_size(struct thread_data *td)
 {
 	unsigned long long ret, sized;
@@ -1242,6 +1331,44 @@ int setup_files(struct thread_data *td)
 
 			err = __file_invalidate_cache(td, f, old_len,
 								extend_len);
+
+			/*
+			 * Shut up static checker
+			 */
+			if (f->fd != -1)
+				close(f->fd);
+
+			f->fd = -1;
+			if (err)
+				break;
+		}
+		temp_stall_ts = 0;
+	}
+
+	if (err)
+		goto err_out;
+
+	/*
+	 * Prepopulate regular files with data. It might be expected
+	 * to read some "real" data instead of zero'ed files (if no writes
+	 * to file occurred prior to a read job).
+	 */
+	if (td->o.prepopulate && td_read(td)) {
+		temp_stall_ts = 1;
+
+		for_each_file(td, f, i) {
+			assert(f->filetype == FIO_TYPE_FILE);
+			if (output_format & FIO_OUTPUT_NORMAL) {
+				log_info("%s: Prepopulating IO file (%s)\n",
+							o->name, f->file_name);
+			}
+
+			err = prepopulate_file(td, f);
+			if (err)
+				break;
+
+			err = __file_invalidate_cache(td, f, f->file_offset,
+								f->io_size);
 
 			/*
 			 * Shut up static checker

--- a/fio.1
+++ b/fio.1
@@ -981,6 +981,14 @@ write to the end of an extended file will stall until the entire
 file has been filled with zeroes.
 .RE
 .TP
+.BI prepopulate \fR=\fPbool
+After laying down files it might be expected to fill them with some data.
+It makes sense only for read jobs (not preceded by a write job).
+It works on regular files and fills them up block by block. It may take
+some time to complete (especially with big file and small block size).
+It makes no sense with fill_device, so don\(aqt use these two together.
+Default: false.
+.TP
 .BI fadvise_hint \fR=\fPstr
 Use \fBposix_fadvise\fR\|(2) or \fBposix_madvise\fR\|(2) to advise the kernel
 what I/O patterns are likely to be issued. Accepted values are:

--- a/options.c
+++ b/options.c
@@ -2490,6 +2490,16 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		},
 	},
 	{
+		.name	= "prepopulate",
+		.lname	= "Prepopulate",
+		.type	= FIO_OPT_BOOL,
+		.off1	= offsetof(struct thread_options, prepopulate),
+		.help	= "Prepopulate files with some data",
+		.def	= "0",
+		.category = FIO_OPT_C_FILE,
+		.group	= FIO_OPT_G_INVALID,
+	},
+	{
 		.name	= "fadvise_hint",
 		.lname	= "Fadvise hint",
 		.type	= FIO_OPT_STR,

--- a/thread_options.h
+++ b/thread_options.h
@@ -229,6 +229,7 @@ struct thread_options {
 	unsigned int stats;
 	unsigned int fadvise_hint;
 	enum fio_fallocate_mode fallocate_mode;
+	unsigned int prepopulate;
 	unsigned int zero_buffers;
 	unsigned int refill_buffers;
 	unsigned int scramble_buffers;
@@ -617,6 +618,9 @@ struct thread_options_pack {
 	uint64_t max_latency;
 	fio_fp64_t latency_percentile;
 	uint32_t latency_run;
+
+
+	uint32_t prepopulate;
 
 	/*
 	 * flow support


### PR DESCRIPTION
When read job is executed and file is zero'ed, results are
higher than expected (because reading zero page).

Signed-off-by: Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>


PR for review purpose. Will be upstreamed to axboe/fio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/119)
<!-- Reviewable:end -->
