### PR TITLE
rpma: gpspm: goto err_ep_shutdown if librpma_common_allocate_pmem() f…

### DIFF
--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -1163,7 +1163,7 @@ static int server_open_file(struct thread_data *td, struct fio_file *f)
 	ws_ptr = librpma_common_allocate_pmem(td, f->file_name, mem_size,
 			&sd->mem);
 	if (ws_ptr == NULL)
-		return 1;
+		goto err_ep_shutdown;
 
 	f->real_file_size = mem_size;
 


### PR DESCRIPTION
Avoid the following compiler warning:
```
engines/librpma_gpspm.c:1282:1: warning: label ‘err_ep_shutdown’ defined but not used
```

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/122)
<!-- Reviewable:end -->
