### PR TITLE
rpma: common: client_queue, client_io_write and client_io_read 

### DIFF
--- a/engines/librpma.c
+++ b/engines/librpma.c
@@ -27,6 +27,13 @@ struct client_data {
 	enum rpma_flush_type flush_type;
 };
 
+static inline int client_io_flush(struct thread_data *td,
+		struct io_u *first_io_u, struct io_u *last_io_u,
+		unsigned long long int len);
+
+static int client_get_io_u_index(struct rpma_completion *cmpl,
+		unsigned int *io_u_index);
+
 static int client_init(struct thread_data *td)
 {
 	struct librpma_common_client_data *ccd;
@@ -149,6 +156,8 @@ static int client_init(struct thread_data *td)
 		(void) rpma_peer_cfg_delete(&pcfg);
 	}
 
+	ccd->flush = client_io_flush;
+	ccd->get_io_u_index = client_get_io_u_index;
 	ccd->client_data = cd;
 
 	return 0;
@@ -172,45 +181,6 @@ static void client_cleanup(struct thread_data *td)
 	free(ccd->client_data);
 
 	librpma_common_client_cleanup(td);
-}
-
-static inline int client_io_read(struct thread_data *td, struct io_u *io_u, int flags)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-	size_t dst_offset = (char *)(io_u->xfer_buf) - ccd->orig_buffer_aligned;
-	size_t src_offset = io_u->offset;
-	int ret = rpma_read(ccd->conn,
-			ccd->orig_mr, dst_offset,
-			ccd->server_mr, src_offset,
-			io_u->xfer_buflen,
-			flags,
-			(void *)(uintptr_t)io_u->index);
-	if (ret) {
-		librpma_td_verror(td, ret, "rpma_read");
-		return -1;
-	}
-
-	return 0;
-}
-
-static inline int client_io_write(struct thread_data *td, struct io_u *io_u)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-	size_t src_offset = (char *)(io_u->xfer_buf) - ccd->orig_buffer_aligned;
-	size_t dst_offset = io_u->offset;
-
-	int ret = rpma_write(ccd->conn,
-			ccd->server_mr, dst_offset,
-			ccd->orig_mr, src_offset,
-			io_u->xfer_buflen,
-			RPMA_F_COMPLETION_ON_ERROR,
-			(void *)(uintptr_t)io_u->index);
-	if (ret) {
-		librpma_td_verror(td, ret, "rpma_write");
-		return -1;
-	}
-
-	return 0;
 }
 
 static inline int client_io_flush(struct thread_data *td,
@@ -240,87 +210,6 @@ static int client_get_io_u_index(struct rpma_completion *cmpl,
 	return 0;
 }
 
-static enum fio_q_status client_queue_sync(struct thread_data *td,
-					  struct io_u *io_u)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-	struct rpma_completion cmpl;
-	unsigned int io_u_index;
-	int ret;
-
-	/* execute io_u */
-	if (io_u->ddir == DDIR_READ) {
-		/* post an RDMA read operation */
-		if ((ret = client_io_read(td, io_u, RPMA_F_COMPLETION_ALWAYS)))
-			goto err;
-	} else if (io_u->ddir == DDIR_WRITE) {
-		/* post an RDMA write operation */
-		if ((ret = client_io_write(td, io_u)))
-			goto err;
-		if ((ret = client_io_flush(td, io_u, io_u, io_u->xfer_buflen)))
-			goto err;
-	} else {
-		log_err("unsupported IO mode: %s\n", io_ddir_name(io_u->ddir));
-		goto err;
-	}
-
-	do {
-		/* get a completion */
-		ret = rpma_conn_completion_get(ccd->conn, &cmpl);
-		if (ret == RPMA_E_NO_COMPLETION) {
-			/* lack of completion is not an error */
-			continue;
-		} else if (ret != 0) {
-			/* an error occurred */
-			librpma_td_verror(td, ret, "rpma_conn_completion_get");
-			goto err;
-		}
-
-		/* if io_us has completed with an error */
-		if (cmpl.op_status != IBV_WC_SUCCESS)
-			goto err;
-
-		if (cmpl.op == RPMA_OP_SEND)
-			++ccd->op_send_completed;
-		else
-			break;
-	} while (1);
-
-	if (client_get_io_u_index(&cmpl, &io_u_index))
-		goto err;
-
-	if (io_u->index != io_u_index) {
-		log_err(
-			"no matching io_u for received completion found (io_u_index=%u)\n",
-			io_u_index);
-		goto err;
-	}
-
-	return FIO_Q_COMPLETED;
-
-err:
-	io_u->error = -1;
-	return FIO_Q_COMPLETED;
-}
-
-static enum fio_q_status client_queue(struct thread_data *td,
-					  struct io_u *io_u)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-
-	if (ccd->io_u_queued_nr == (int)td->o.iodepth)
-		return FIO_Q_BUSY;
-
-	if (td->o.sync_io)
-		return client_queue_sync(td, io_u);
-
-	/* io_u -> queued[] */
-	ccd->io_us_queued[ccd->io_u_queued_nr] = io_u;
-	ccd->io_u_queued_nr++;
-
-	return FIO_Q_QUEUED;
-}
-
 static int client_commit(struct thread_data *td)
 {
 	struct librpma_common_client_data *ccd = td->io_ops_data;
@@ -343,11 +232,11 @@ static int client_commit(struct thread_data *td)
 			if (i + 1 == ccd->io_u_queued_nr || ccd->io_us_queued[i + 1]->ddir == DDIR_WRITE)
 				flags = RPMA_F_COMPLETION_ALWAYS;
 			/* post an RDMA read operation */
-			if ((ret = client_io_read(td, io_u, flags)))
+			if ((ret = librpma_common_client_io_read(td, io_u, flags)))
 				return -1;
 		} else if (io_u->ddir == DDIR_WRITE) {
 			/* post an RDMA write operation */
-			ret = client_io_write(td, io_u);
+			ret = librpma_common_client_io_write(td, io_u);
 			if (ret)
 				return -1;
 
@@ -568,7 +457,7 @@ FIO_STATIC struct ioengine_ops ioengine_client = {
 	.post_init		= librpma_common_client_post_init,
 	.get_file_size		= librpma_common_client_get_file_size,
 	.open_file		= librpma_common_file_nop,
-	.queue			= client_queue,
+	.queue			= librpma_common_client_queue,
 	.commit			= client_commit,
 	.getevents		= client_getevents,
 	.event			= client_event,

--- a/engines/librpma_common.c
+++ b/engines/librpma_common.c
@@ -349,6 +349,87 @@ int librpma_common_client_get_file_size(struct thread_data *td,
 	return 0;
 }
 
+static enum fio_q_status client_queue_sync(struct thread_data *td,
+					  struct io_u *io_u)
+{
+	struct librpma_common_client_data *ccd = td->io_ops_data;
+	struct rpma_completion cmpl;
+	unsigned int io_u_index;
+	int ret;
+
+	/* execute io_u */
+	if (io_u->ddir == DDIR_READ) {
+		/* post an RDMA read operation */
+		if ((ret = librpma_common_client_io_read(td, io_u, RPMA_F_COMPLETION_ALWAYS)))
+			goto err;
+	} else if (io_u->ddir == DDIR_WRITE) {
+		/* post an RDMA write operation */
+		if ((ret = librpma_common_client_io_write(td, io_u)))
+			goto err;
+		if ((ret = ccd->flush(td, io_u, io_u, io_u->xfer_buflen)))
+			goto err;
+	} else {
+		log_err("unsupported IO mode: %s\n", io_ddir_name(io_u->ddir));
+		goto err;
+	}
+
+	do {
+		/* get a completion */
+		ret = rpma_conn_completion_get(ccd->conn, &cmpl);
+		if (ret == RPMA_E_NO_COMPLETION) {
+			/* lack of completion is not an error */
+			continue;
+		} else if (ret != 0) {
+			/* an error occurred */
+			librpma_td_verror(td, ret, "rpma_conn_completion_get");
+			goto err;
+		}
+
+		/* if io_us has completed with an error */
+		if (cmpl.op_status != IBV_WC_SUCCESS)
+			goto err;
+
+		if (cmpl.op == RPMA_OP_SEND)
+			++ccd->op_send_completed;
+		else
+			break;
+	} while (1);
+
+	if (ccd->get_io_u_index(&cmpl, &io_u_index))
+		goto err;
+
+	if (io_u->index != io_u_index) {
+		log_err(
+			"no matching io_u for received completion found (io_u_index=%u)\n",
+			io_u_index);
+		goto err;
+	}
+
+	return FIO_Q_COMPLETED;
+
+err:
+	io_u->error = -1;
+	return FIO_Q_COMPLETED;
+}
+
+enum fio_q_status librpma_common_client_queue(struct thread_data *td,
+		struct io_u *io_u)
+{
+	struct librpma_common_client_data *ccd = td->io_ops_data;
+
+	if (ccd->io_u_queued_nr == (int)td->o.iodepth)
+		return FIO_Q_BUSY;
+
+	if (td->o.sync_io)
+		return client_queue_sync(td, io_u);
+
+	/* io_u -> queued[] */
+	ccd->io_us_queued[ccd->io_u_queued_nr] = io_u;
+	ccd->io_u_queued_nr++;
+
+	return FIO_Q_QUEUED;
+}
+
 struct fio_option librpma_common_fio_server_options[] = {
 	{
 		.name	= "bindname",

--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -61,6 +61,13 @@ struct client_data {
 	struct rpma_mr_local *msg_mr;
 };
 
+static inline int client_io_flush(struct thread_data *td,
+		struct io_u *first_io_u, struct io_u *last_io_u,
+		unsigned long long int len);
+
+static int client_get_io_u_index(struct rpma_completion *cmpl,
+		unsigned int *io_u_index);
+
 static int client_init(struct thread_data *td)
 {
 	struct librpma_common_client_data *ccd;
@@ -69,8 +76,12 @@ static int client_init(struct thread_data *td)
 	struct rpma_conn_cfg *cfg = NULL;
 	int ret;
 	
-	/* not supported readwrite = read / trim / randread / randtrim / rw / randrw / trimwrite */
-	if (td_read(td) || td_trim(td)) {
+	/*
+	 * not supported:
+	 * -  sync_io: readwrite = trim / randtrim / trimwrite
+	 * - !sync_io: readwrite = read / trim / randread / randtrim / rw / randrw / trimwrite
+	 */
+	if ((td_read(td) && (!td->o.sync_io)) || td_trim(td)) {
 		log_err("Not supported mode.\n");
 		return 1;
 	}
@@ -150,6 +161,8 @@ static int client_init(struct thread_data *td)
 		goto err_cleanup_common;
 	}
 
+	ccd->flush = client_io_flush;
+	ccd->get_io_u_index = client_get_io_u_index;
 	ccd->client_data = cd;
 
 	return 0;
@@ -258,26 +271,6 @@ static void client_cleanup(struct thread_data *td)
 	librpma_common_client_cleanup(td);
 }
 
-static inline int client_io_write(struct thread_data *td, struct io_u *io_u)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-	size_t src_offset = (char *)(io_u->xfer_buf) - ccd->orig_buffer_aligned;
-	size_t dst_offset = io_u->offset;
-
-	int ret = rpma_write(ccd->conn,
-			ccd->server_mr, dst_offset,
-			ccd->orig_mr, src_offset,
-			io_u->xfer_buflen,
-			RPMA_F_COMPLETION_ON_ERROR,
-			NULL);
-	if (ret) {
-		librpma_td_verror(td, ret, "rpma_write");
-		return -1;
-	}
-
-	return 0;
-}
-
 static inline int client_io_flush(struct thread_data *td,
 		struct io_u *first_io_u, struct io_u *last_io_u,
 		unsigned long long int len)
@@ -347,82 +340,6 @@ static int client_get_io_u_index(struct rpma_completion *cmpl,
 	return 0;
 }
 
-static enum fio_q_status client_queue_sync(struct thread_data *td,
-					  struct io_u *io_u)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-	struct rpma_completion cmpl;
-	unsigned int io_u_index;
-	int ret;
-
-	if (io_u->ddir != DDIR_WRITE) {
-		log_err("unsupported IO mode: %s\n", io_ddir_name(io_u->ddir));
-		return -1;
-	}
-
-	/* post an RDMA write operation */
-	if ((ret = client_io_write(td, io_u)))
-		goto err;
-	if ((ret = client_io_flush(td, io_u, io_u, io_u->xfer_buflen)))
-		goto err;
-
-	do {
-		/* get a completion */
-		ret = rpma_conn_completion_get(ccd->conn, &cmpl);
-		if (ret == RPMA_E_NO_COMPLETION) {
-			/* lack of completion is not an error */
-			continue;
-		} else if (ret != 0) {
-			/* an error occurred */
-			librpma_td_verror(td, ret, "rpma_conn_completion_get");
-			goto err;
-		}
-
-		/* if io_us has completed with an error */
-		if (cmpl.op_status != IBV_WC_SUCCESS)
-			goto err;
-
-		if (cmpl.op == RPMA_OP_SEND)
-			++ccd->op_send_completed;
-		else
-			break;
-	} while (1);
-
-	if (client_get_io_u_index(&cmpl, &io_u_index))
-		goto err;
-
-	if (io_u->index != io_u_index) {
-		log_err(
-			"no matching io_u for received completion found (io_u_index=%u)\n",
-			io_u_index);
-		goto err;
-	}
-
-	return FIO_Q_COMPLETED;
-
-err:
-	io_u->error = -1;
-	return FIO_Q_COMPLETED;
-}
-
-static enum fio_q_status client_queue(struct thread_data *td,
-					  struct io_u *io_u)
-{
-	struct librpma_common_client_data *ccd = td->io_ops_data;
-
-	if (ccd->io_u_queued_nr == (int)td->o.iodepth)
-		return FIO_Q_BUSY;
-
-	if (td->o.sync_io)
-		return client_queue_sync(td, io_u);
-
-	/* io_u -> queued[] */
-	ccd->io_us_queued[ccd->io_u_queued_nr] = io_u;
-	ccd->io_u_queued_nr++;
-
-	return FIO_Q_QUEUED;
-}
-
 static int client_commit(struct thread_data *td)
 {
 	struct librpma_common_client_data *ccd = td->io_ops_data;
@@ -446,7 +363,7 @@ static int client_commit(struct thread_data *td)
 		}
 
 		/* post an RDMA write operation */
-		ret = client_io_write(td, io_u);
+		ret = librpma_common_client_io_write(td, io_u);
 		if (ret)
 			return -1;
 
@@ -529,7 +446,6 @@ static int client_getevent_process(struct thread_data *td)
 	int cmpl_num = 0;
 	/* helpers */
 	struct io_u *io_u;
-	GPSPMFlushResponse *flush_resp;
 	int i;
 	int ret;
 
@@ -668,7 +584,7 @@ FIO_STATIC struct ioengine_ops ioengine_client = {
 	.post_init		= client_post_init,
 	.get_file_size		= librpma_common_client_get_file_size,
 	.open_file		= librpma_common_file_nop,
-	.queue			= client_queue,
+	.queue			= librpma_common_client_queue,
 	.commit			= client_commit,
 	.getevents		= client_getevents,
 	.event			= client_event,


### PR DESCRIPTION
**Note**: This change may affect engines performance because io functions may be linked differently. Especially io_flush function is provided via a function pointer which prevents any compile-time optimizations.

**Note**: This change silently introduces read for GPSPM sync workloads which requires verification.

Requires:
- [x] #130
- [x] #134

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/131)
<!-- Reviewable:end -->
