### PR TITLE
rpma: common: get_io_u_index() skip

### DIFF
--- a/engines/librpma.c
+++ b/engines/librpma.c
@@ -203,7 +203,7 @@ static int client_get_io_u_index(struct rpma_completion *cmpl,
 {
 	memcpy(io_u_index, &cmpl->op_context, sizeof(unsigned int));
 
-	return 0;
+	return 1;
 }
 
 FIO_STATIC struct ioengine_ops ioengine_client = {

--- a/engines/librpma_common.c
+++ b/engines/librpma_common.c
@@ -409,7 +409,7 @@ static enum fio_q_status client_queue_sync(struct thread_data *td,
 			break;
 	} while (1);
 
-	if (ccd->get_io_u_index(&cmpl, &io_u_index))
+	if (ccd->get_io_u_index(&cmpl, &io_u_index) != 1)
 		goto err;
 
 	if (io_u->index != io_u_index) {
@@ -585,15 +585,11 @@ static int client_getevent_process(struct thread_data *td)
 		return -1;
 	}
 
-	if (cmpl.op != RPMA_OP_RECV) {
-		if (cmpl.op == RPMA_OP_SEND)
-			++ccd->op_send_completed;
+	if (cmpl.op == RPMA_OP_SEND)
+		++ccd->op_send_completed;
 
-		return 0;
-	}
-
-	if (ccd->get_io_u_index(&cmpl, &io_u_index))
-		return -1;
+	if ((ret = ccd->get_io_u_index(&cmpl, &io_u_index)) != 1)
+		return ret;
 
 	/* look for an io_u being completed */
 	for (i = 0; i < ccd->io_u_flight_nr; ++i) {

--- a/engines/librpma_common.h
+++ b/engines/librpma_common.h
@@ -84,6 +84,12 @@ typedef int (*librpma_common_flush_t)(struct thread_data *td,
 		struct io_u *first_io_u, struct io_u *last_io_u,
 		unsigned long long int len);
 
+/*
+ * RETURN VALUE
+ * - ( 1) - on success
+ * - ( 0) - skip
+ * - (-1) - on error
+ */
 typedef int (*librpma_common_get_io_u_index_t)(struct rpma_completion *cmpl,
 		unsigned int *io_u_index);
 

--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -314,7 +314,7 @@ static int client_get_io_u_index(struct rpma_completion *cmpl,
 	GPSPMFlushResponse *flush_resp;
 
 	if (cmpl->op != RPMA_OP_RECV)
-		return -1;
+		return 0;
 
 	/* unpack a response from the received buffer */
 	flush_resp = gpspm_flush_response__unpack(NULL,
@@ -328,7 +328,7 @@ static int client_get_io_u_index(struct rpma_completion *cmpl,
 
 	gpspm_flush_response__free_unpacked(flush_resp, NULL);
 
-	return 0;
+	return 1;
 }
 
 FIO_STATIC struct ioengine_ops ioengine_client = {


### PR DESCRIPTION
- get_io_u_index() is getting three possible return values:
    - (-1) - on error
    - ( 0) - skip
    - ( 1) - on success
- client_getevents_process() fix by taking into account
  the mentioned above possibility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/150)
<!-- Reviewable:end -->
