### PR TITLE
rpma: fix warning about unused label ‘err_free_ccd’

### DIFF
--- a/engines/librpma_common.c
+++ b/engines/librpma_common.c
@@ -182,7 +182,7 @@ int librpma_common_client_init(struct thread_data *td, struct rpma_conn_cfg *cfg
 	ccd->io_us_queued = calloc(td->o.iodepth, sizeof(*ccd->io_us_queued));
 	if (ccd->io_us_queued == NULL) {
 		td_verror(td, errno, "calloc");
-		goto err_free_io_u_queues;
+		goto err_free_ccd;
 	}
 
 	ccd->io_us_flight = calloc(td->o.iodepth, sizeof(*ccd->io_us_flight));


### PR DESCRIPTION
Fix the warning:
```
engines/librpma_common.c: In function ‘librpma_common_client_init’:
engines/librpma_common.c:279:1: warning: label ‘err_free_ccd’ defined but not used [-Wunused-label]
  279 | err_free_ccd:
      | ^~~~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/167)
<!-- Reviewable:end -->
