### PR TITLE
rpma: Don't break the json output format

### DIFF
--- a/engines/librpma.c
+++ b/engines/librpma.c
@@ -129,9 +129,11 @@ static int client_init(struct thread_data *td)
 
 		(void) rpma_peer_cfg_delete(&pcfg);
 	} else {
-		log_info(
-			"Note: Direct Write to PMem is not supported by default nor required if you use DRAM instead of PMem on the server side (direct_write_to_pmem).\n"
-			"Remember that flushing to DRAM does not make your data persistent and may be used only for experimental purposes.\n");
+		if (output_format & FIO_OUTPUT_NORMAL) {
+			log_info(
+				"Note: Direct Write to PMem is not supported by default nor required if you use DRAM instead of PMem on the server side (direct_write_to_pmem).\n"
+				"Remember that flushing to DRAM does not make your data persistent and may be used only for experimental purposes.\n");
+		}
 	}
 
 	if ((ret = rpma_conn_cfg_delete(&cfg))) {

--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -142,7 +142,7 @@ static int client_init(struct thread_data *td)
 	ccd = td->io_ops_data;
 
 	if (ccd->ws->direct_write_to_pmem) {
-		if (ccd->server_mr_flush_type == RPMA_FLUSH_TYPE_PERSISTENT) {
+		if ((ccd->server_mr_flush_type == RPMA_FLUSH_TYPE_PERSISTENT) && (output_format & FIO_OUTPUT_NORMAL)) {
 			log_info(
 				"Note: The server side supports Direct Write to PMem and it is equipped with PMem (direct_write_to_pmem).\n"
 				"You can use librpma_client and librpma_server engines for better performance instead of GPSPM.\n");


### PR DESCRIPTION
Some hints break the json output format so that
fio_json2csv.py cannot convert json to csv.
```
$ head -n6 /dev/shm/rpma_fio_apm_rw_lat_th1_dp1_dram-21-01-21-193616_temp.json
Note: Direct Write to PMem is not supported by default nor required if you use DRAM instead of PMem on the server side (direct_write_to_pmem).
Remember that flushing to DRAM does not make your data persistent and may be used only for experimental purposes.
{
  "fio version" : "fio-3.23-370-gdcd5",
  "timestamp" : 1611229062,
  "timestamp_ms" : 1611229062660,
...
```

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/177)
<!-- Reviewable:end -->
