### PR TITLE
rpma: apm .fio example file with real values for latency measurement

### DIFF
--- a/examples/librpma_apm-client.fio
+++ b/examples/librpma_apm-client.fio
@@ -3,22 +3,22 @@
 [global]
 ioengine=librpma_apm_client
 create_serialize=0 # (required) forces specific initiation sequence
-serverip=[IP address the server is listening on]
-port=[port the server is listening on]
+serverip=[serverip] #IP address the server is listening on
+port=7204 # port(s) the server will listen on, <port; port + numjobs - 1> will be used
 thread
 
 # The client will get a remote memory region description after establishing
 # a connection.
 
 [client]
-numjobs=[# of connections]
+numjobs=1 # number of parallel connection
 group_reporting=1
-sync=[1 is the best for latency measurements]
-iodepth=[total # of ious]
-iodepth_batch_submit=[# of ious to submit at once]
-readwrite=[read/write/randread/randwrite/readwrite/rw]
-rwmixread=[% of a mixed workload that should be reads]
-blocksize=[block size]
-ramp_time=[gives some time to stabilize the workload]
+sync=1 # 1 is the best for latency measurements, 0 for bandwidth
+iodepth=2 # total # of ious
+iodepth_batch_submit=1 # of ious to submit at once
+rw=write # [read/write/randread/randwrite/readwrite/rw]
+rwmixread=70 # % of a mixed workload that should be reads
+blocksize=4KiB
+ramp_time=15s # gives some time to stabilize the workload
 time_based
-runtime=[run the workload for the specified period of time]
+runtime=60s # run the workload for the specified period of time

--- a/examples/librpma_apm-server.fio
+++ b/examples/librpma_apm-server.fio
@@ -1,11 +1,11 @@
-# Example of the librpma_apm server job
+# Example of the librpma_apm-server job
 
 [global]
 ioengine=librpma_apm_server
 create_serialize=0 # (required) forces specific initiation sequence
 kb_base=1000 # turn on the straight units handling (non-compatibility mode)
-serverip=[IP address to listen on]
-port=[base port; ports <port; port + numjobs - 1> will be used]
+serverip=[serverip] # IP address to listen on
+port=7204 # port(s) the server jobs will listen on, ports <port; port + numjobs - 1> will be used
 thread
 
 # The server side spawns one thread for each expected connection from
@@ -18,7 +18,9 @@ thread
 [server]
 # set to 1 (true) ONLY when Direct Write to PMem from the remote host is possible
 # (https://pmem.io/rpma/documentation/basic-direct-write-to-pmem.html)
-direct_write_to_pmem=${direct_write_to_pmem}
-numjobs=[# of expected connections]
-size=[size of workspace for a single connection]
-filename=[device dax or an existing fsdax file or "malloc" for allocation from DRAM]
+direct_write_to_pmem=0
+
+numjobs=1 # number of expected incomming connections
+size=100MiB # size of workspace for a single connection
+filename=malloc # device dax or an existing fsdax file or "malloc" for allocation from DRAM
+# filename=/dev/dax1.0


### PR DESCRIPTION
rpma: apm .fio example file with real values for latency measurement

The librpma-apm-*.fio example configurations files should be as complete as possible.
The only ip should be adjusted if needed.
DRAM/malloc is selected for the purpose that the engine could be started without PMem

Requires:
* [x] #186 (in most part an independent change)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/187)
<!-- Reviewable:end -->
