### PR TITLE
ci: update apt before installing packages

### DIFF
--- a/ci/actions-install.sh
+++ b/ci/actions-install.sh
@@ -68,6 +68,11 @@ DPKGCFG
 
     echo "Updating APT..."
     sudo apt-get -qq update
+
+    # Update the 'apt' package in order to fix the following bug:
+    # https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268
+    sudo apt-get install --no-install-recommends -qq -y apt
+
     echo "Installing packages..."
     sudo apt-get install --no-install-recommends -qq -y "${pkgs[@]}"
     # librpma is supported on the x86_64 architecture for now


### PR DESCRIPTION
The 'apt' package should be updated before installing packages
in order to fix the following bug:
https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268

It fixes the linux i686 schedule build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/199)
<!-- Reviewable:end -->
