### PR TITLE
ci: fix MacOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         - linux-i686-gcc
         include:
         - build: macos
-          os: macos-11.0
+          os: macos-10.15
         - build: linux-i686-gcc
           os: ubuntu-20.04
           arch: i686

--- a/configure
+++ b/configure
@@ -360,17 +360,6 @@ Darwin)
   if test -z "$cpu" && test "$(sysctl -n hw.optional.x86_64)" = "1"; then
     cpu="x86_64"
   fi
-  # Error at compile time linking of weak/partial symbols if possible...
-cat > $TMPC <<EOF
-int main(void)
-{
-  return 0;
-}
-EOF
-  if compile_prog "" "-Wl,-no_weak_imports" "disable weak symbols"; then
-    echo "Disabling weak symbols"
-    LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
-  fi
   ;;
 SunOS)
   # `uname -m` returns i86pc even on an x86_64 box, so default based on isainfo


### PR DESCRIPTION
The macOS 11.0 ('macos-11.0') virtual environment is currently
provided as a private preview only:
https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/200)
<!-- Reviewable:end -->
