### PR TITLE
ci: add the APT::Immediate-Configure APT option

### DIFF
--- a/ci/actions-install.sh
+++ b/ci/actions-install.sh
@@ -69,7 +69,7 @@ DPKGCFG
     echo "Updating APT..."
     sudo apt-get -qq update
     echo "Installing packages..."
-    sudo apt-get install --no-install-recommends -qq -y "${pkgs[@]}"
+    sudo apt-get install -o APT::Immediate-Configure=false --no-install-recommends -qq -y "${pkgs[@]}"
     # librpma is supported on the x86_64 architecture for now
     if [[ $CI_TARGET_ARCH == "x86_64" ]]; then
         # install libprotobuf-c-dev required by librpma_gpspm


### PR DESCRIPTION
Add the APT::Immediate-Configure APT option.
It fixes the linux i686 schedule build.

See: https://github.com/axboe/fio/pull/1157
See: https://bugs.launchpad.net/ubuntu-cdimage/+bug/1871268

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/201)
<!-- Reviewable:end -->
