### PR TITLE
rpma: zero the librpma_fio_workspace structure

### DIFF
--- a/engines/librpma_fio.c
+++ b/engines/librpma_fio.c
@@ -871,7 +871,7 @@ int librpma_fio_server_open_file(struct thread_data *td, struct fio_file *f,
 	struct librpma_fio_server_data *csd = td->io_ops_data;
 	struct librpma_fio_options_values *o = td->eo;
 	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
-	struct librpma_fio_workspace ws;
+	struct librpma_fio_workspace ws = {0};
 	struct rpma_conn_private_data pdata;
 	uint32_t max_msg_num;
 	struct rpma_conn_req *conn_req;


### PR DESCRIPTION
It fixes the following memcheck's issue:

==450778== Thread 20:
==450778== Syscall param write(buf) points to uninitialised byte(s)
==450778==    at 0x526FAF7: __libc_write (write.c:26)
==450778==    by 0x526FAF7: write (write.c:24)
==450778==    by 0x5C29D14: rdma_accept (cma.c:1681)
==450778==    by 0x4040F6C: rpma_conn_req_accept (conn_req.c:134)
==450778==    by 0x4041B2E: rpma_conn_req_connect (conn_req.c:421)
==450778==    by 0x4950FE: librpma_fio_server_open_file (librpma_fio.c:978)
==450778==    by 0x4B1C92: server_open_file (librpma_gpspm.c:557)
==450778==    by 0x423D96: td_io_open_file (ioengines.c:502)
==450778==    by 0x44EFD2: get_next_file_rr (io_u.c:1294)
==450778==    by 0x44F23E: __get_next_file (io_u.c:1343)
==450778==    by 0x44F329: get_next_file (io_u.c:1362)
==450778==    by 0x44F347: set_io_u_file (io_u.c:1370)
==450778==    by 0x450406: get_io_u (io_u.c:1765)
==450778==  Address 0x5d6948c1 is on thread 20's stack
==450778==  in frame #1, created by rdma_accept (cma.c:1640)
==450778==  Uninitialised value was created by a stack allocation
==450778==    at 0x4945DF: librpma_fio_server_open_file (librpma_fio.c:870)
==450778==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/236)
<!-- Reviewable:end -->
