### PR TITLE
rpma: add FIO_DISKLESSIO flag for server ioengine

### DIFF
--- a/engines/librpma_aof.c
+++ b/engines/librpma_aof.c
@@ -1109,7 +1109,7 @@ FIO_STATIC struct ioengine_ops ioengine_server = {
 	.queue			= server_queue_temp, /* see the (*) notice below */
 	.invalidate		= librpma_fio_file_nop,
 	.cleanup		= NULL, /* see the (*) notice below */
-	.flags			= FIO_SYNCIO,
+	.flags			= FIO_SYNCIO | FIO_DISKLESSIO,
 	.options		= librpma_aof_options,
 	.option_struct_size	= sizeof(struct librpma_fio_options_values),
 

--- a/engines/librpma_apm.c
+++ b/engines/librpma_apm.c
@@ -234,7 +234,7 @@ FIO_STATIC struct ioengine_ops ioengine_server = {
 	.queue			= server_queue,
 	.invalidate		= librpma_fio_file_nop,
 	.cleanup		= librpma_fio_server_cleanup,
-	.flags			= FIO_SYNCIO,
+	.flags			= FIO_SYNCIO | FIO_DISKLESSIO,
 	.options		= librpma_fio_options,
 	.option_struct_size	= sizeof(struct librpma_fio_options_values),
 };

--- a/engines/librpma_gpspm.c
+++ b/engines/librpma_gpspm.c
@@ -756,7 +756,7 @@ FIO_STATIC struct ioengine_ops ioengine_server = {
 	.queue			= server_queue,
 	.invalidate		= librpma_fio_file_nop,
 	.cleanup		= server_cleanup,
-	.flags			= FIO_SYNCIO,
+	.flags			= FIO_SYNCIO | FIO_DISKLESSIO,
 	.options		= librpma_fio_options,
 	.option_struct_size	= sizeof(struct librpma_fio_options_values),
 };


### PR DESCRIPTION
@grom72 @janekmi @ldorau 

When we use 64 threads to run server ioengine with DRAM, setup_files() will create the unused 'malloc' file by some operations (e.g. fallocate, ftruncate).  This behavior makes server spend more time to prepare the connection so that client always triggers the "The maximum number of retries exceeded." error.  See the detailed output:
```
...
Thread [7]: The maximum number of retries exceeded. Closing. IOPS][eta 01m:00s]
Thread [7]: Connected after retry #10
Thread [29]: Connected after retry #9
Thread [2]: The maximum number of retries exceeded. Closing.
Thread [9]: The maximum number of retries exceeded. Closing.
Thread [2]: Connected after retry #10
Thread [9]: Connected after retry #10
Thread [15]: The maximum number of retries exceeded. Closing.
Thread [15]: Connected after retry #10
Thread [19]: The maximum number of retries exceeded. Closing.
Thread [19]: Connected after retry #10
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15279, err=-1/
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15284, err=-1/
fio: pid=15292, err=-1/
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15286, err=-1/
fio: pid=15296, err=-1/
Thread [30]: The maximum number of retries exceeded. Closing.
Thread [30]: Connected after retry #10
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15307, err=-1/
...
```

disallow setup_files() to create the unused 'malloc' file by adding FIO_DISKLESSIO flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/fio/257)
<!-- Reviewable:end -->
